### PR TITLE
Allow running the stack behind a TLS-terminating proxy

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -29,6 +29,14 @@ http {
       keepalive 32;
     }
 
+    # If we run behind a load balancer doing TLS termination (like AWS ALB),
+    # forward down the X-Forwarded-Proto header if it's set.
+    # kindly taken from https://stackoverflow.com/a/21911864
+    map $http_x_forwarded_proto $real_scheme {
+        default $http_x_forwarded_proto;
+        ''      $scheme;
+    }
+
     server {
         access_log off;
         listen 8000 deferred;
@@ -53,7 +61,7 @@ http {
 
         location / {
             proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
-            proxy_set_header    X-Forwarded-Proto   $scheme;
+            proxy_set_header    X-Forwarded-Proto   $real_scheme;
             proxy_set_header    Host                $host;
             # we don't want nginx trying to do something clever with
             # redirects, we set the Host: header above already.


### PR DESCRIPTION
If request NGINX receives already has a X-Forward-Proto header, use its
value instead of scheme extracted from the URI.